### PR TITLE
Update Enum Definitions to Use Positional Arguments for Rails 8.0 Compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    status_assignable (0.1.3)
+    status_assignable (0.1.5)
       rails (~> 7.1)
 
 GEM
@@ -111,6 +111,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.22.3)
     mutex_m (0.2.0)
     net-imap (0.4.10)
@@ -123,6 +124,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
+    nokogiri (1.16.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.16.3-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.16.3-arm-linux)
@@ -224,6 +228,7 @@ PLATFORMS
   aarch64-linux
   arm-linux
   arm64-darwin
+  ruby
   x86-linux
   x86_64-darwin
   x86_64-linux

--- a/lib/status_assignable.rb
+++ b/lib/status_assignable.rb
@@ -40,7 +40,7 @@ module StatusAssignable
 
   included do # rubocop:disable Metrics/BlockLength
     define_callbacks :soft_destroy, scope: %i[kind name]
-    enum status: StatusAssignable.status_dictionary
+    enum :status, StatusAssignable.status_dictionary
     StatusAssignable.clear_dictionary
 
     # Updates the status of the record directly to the database.

--- a/lib/status_assignable/version.rb
+++ b/lib/status_assignable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StatusAssignable
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Updates the enum definitions across the codebase to replace keyword arguments with positional arguments. This change ensures compliance with the following deprecation warning in Rails:

> DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed in Rails 8.0. Positional arguments should be used instead.

from:
```ruby
enum status: { deleted: 0, active: 1, inactive: 2 }
```

to:
```ruby
enum :status, { deleted: 0, active: 1, inactive: 2 }
```