### PR TITLE
Archive flag destroy option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    status_assignable (0.1.7)
+    status_assignable (0.1.8)
       rails (>= 7.1, < 9)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    status_assignable (0.1.6)
+    status_assignable (0.1.7)
       rails (>= 7.1, < 9)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy, archive: :callbacks
   has_many :comments, dependent: :delete_all, archive: :assign
+  has_many :favorites, dependent: :destroy, archive: :destroy
 end
 ```
 
-The `archive` option can be set to `:callbacks` or `:assign`. If set to `:callbacks`, the associated records will be archived using `soft_destroy`. If set to `:assign`, the associated records will have their status columns assigned directly.
+The `archive` option can be set to `:callbacks`, `:assign` or `:destroy`. If set to `:callbacks`, the associated records will be archived using `soft_destroy`. If set to `:assign`, the associated records will have their status columns assigned directly. If set to `:destroy`, the associated records will be directly destroyed.
 
 It is important that the associations also are `StatusAssignable`!
 

--- a/lib/status_assignable.rb
+++ b/lib/status_assignable.rb
@@ -97,6 +97,7 @@ module StatusAssignable
         case archive_procedure
         when :callbacks then callbacks_method(query)
         when :assign then assign_method(query)
+        when :destroy then destroy_method(query)
         end
       end
     end
@@ -107,6 +108,10 @@ module StatusAssignable
 
     def assign_method(query)
       query.respond_to?(:update_all) ? query.update_all(archive_params) : query&.update_columns(archive_params)
+    end
+
+    def destroy_method(query)
+      query.respond_to?(:each) ? query.each(&:destroy) : query&.destroy
     end
   end
 end

--- a/lib/status_assignable/association.rb
+++ b/lib/status_assignable/association.rb
@@ -5,7 +5,7 @@ module StatusAssignable
   # The values accepted by the :archive option are :callbacks and :assign.
   module Association
     CUSTOM_VALID_OPTIONS = [:archive].freeze
-    VALID_ARCHIVE_OPTIONS = %i[callbacks assign].freeze
+    VALID_ARCHIVE_OPTIONS = %i[callbacks assign destroy].freeze
 
     private
 

--- a/lib/status_assignable/version.rb
+++ b/lib/status_assignable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StatusAssignable
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end

--- a/lib/status_assignable/version.rb
+++ b/lib/status_assignable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StatusAssignable
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end


### PR DESCRIPTION
Add destroy option to archive flag.
This allows flexibility to delete associated records instead of soft deleting them.